### PR TITLE
Export animation does nothing after successful animation import

### DIFF
--- a/supcom-exporter.py
+++ b/supcom-exporter.py
@@ -1101,7 +1101,7 @@ def export_scm(outdir):
     loc_filename = arm_obj.name + '.scm'
     my_popup_info("Object saved to " + loc_filename)
 
-def find_armature():
+def find_armature() -> bpy.types.Armature:
     scene = bpy.context.scene #TODO:prioritise visible objects over this
 
     # Get Selected object(s)
@@ -1145,15 +1145,22 @@ def export_sca(outdir):
 
     # SCA
     # This plays through every action in the NLA tracks linked to our armature and records the relevant bone positions every frame, then saves that to sca
+    nla_strips = list()
     for track in arm_obj.animation_data.nla_tracks:
-        for NlaStrip in track.strips:
-            #set active action
-            arm_obj.animation_data.action = NlaStrip.action
-            
-            animation = make_sca(arm_obj, NlaStrip.action)
-            animation.save(outdir + NlaStrip.action.name + ".sca")
-            
-            my_popup_info("Action saved to " + NlaStrip.action.name)
+        nla_strips.extend(track.strips)
+    
+    if len(nla_strips) == 0:
+        my_popup("No animation strips were found to export. You may need to go to the Nonlinear Animation Editor and hit Push Down Action on your Action.")
+        return
+
+    for nla_strip in nla_strips:
+        #set active action
+        arm_obj.animation_data.action = nla_strip.action
+        
+        animation = make_sca(arm_obj, nla_strip.action)
+        animation.save(outdir + nla_strip.action.name + ".sca")
+        
+        my_popup_info("Action saved to " + nla_strip.action.name)
 
 
 

--- a/supcom-exporter.py
+++ b/supcom-exporter.py
@@ -84,16 +84,11 @@ bl_info = {
 
 import bpy
 
-from bgl import *
-
 from mathutils import *
 
-import os
 from os import path
 
 import struct
-import string
-import math
 from math import *
 from bpy_extras.io_utils import unpack_list, unpack_face_list
 
@@ -1197,7 +1192,6 @@ class EXPORT_OT_scm(bpy.types.Operator):
     def execute(self, context):
         global inError
         inError = 0
-        scene = bpy.context.scene
 
         export_scm(self.directory)
 
@@ -1239,7 +1233,6 @@ class EXPORT_OT_sca(bpy.types.Operator):
     def execute(self, context):
         global inError
         inError = 0
-        scene = bpy.context.scene
         export_sca(self.directory)
 
         return {'FINISHED'}


### PR DESCRIPTION
Hi,
when I tried to use the importer/exporter for animations I ran into an obstacle where I could not get the basic "sanity check" scenario to work, that is:

1. Create a new project
2. Import SupCom mesh UEB2108_lod0.scm
3. Verify the mesh is loaded as expected
4. Import SupCom animation UEB2108_Aopen.sca
5. Verify the animation is loaded as expected by playing it in the Dope Sheet editor.
6. Export SupCom animation to an empty folder

**Expected**: Either the sca file is now present in the folder or the exporter reports an error.
**Actual**: The folder is still empty and no error is reported.

Root cause:
The animation import does not put the animation under NLA strips but the exporter loops over all NLA strips and exports them one by one. If there are no strips, it does nothing and ends.

Fix:
I don't know if experienced users figure this out much faster but even for them it won't hurt if the exporter reports that it didn't find any animation strips and offers a hint. That's what the first commit does.
I have contemplated actually prompting the user whether they want the exporter to execute the pushdown but the API seems to be quite awkward to achieve that and I have little knowledge of blender animations so I'm not sure I could make it smart enough to deal with all possible scenarios.

The second commit is a trivial refactor and it's not required to make the first commit work, I have tested with and without it.